### PR TITLE
Lock base image and change docker-compose name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:focal
+FROM lsiobase/ubuntu:a7da6fde-ls13
 LABEL maintainer="RandomNinjaAtk"
 
 ENV TITLE="Automated Music Video Downloader (AMVD)"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Compatible with docker-compose v2 schemas.
 ```
 version: "2.1"
 services:
-  amd:
+  amvd:
     image: randomninjaatk/amvd 
     container_name: amvd
     volumes:


### PR DESCRIPTION
Lock base image to older version of lsiobase/ubuntu. (To the Nov 1 build)
Fixes the cont-init.d permission denied errors.

Change docker-compose example name to amvd instead of amd.